### PR TITLE
fix: schedule direct token caching

### DIFF
--- a/configure.go
+++ b/configure.go
@@ -29,8 +29,11 @@ func Configure(filename string) (err error) {
 		return err
 	}
 
+	Cache.Open()
+
 	if len(Config.Account.Username) != 0 || len(Config.Account.Password) != 0 {
 		sd.Login()
+		Cache.Save()
 		sd.Status()
 	}
 
@@ -57,6 +60,7 @@ func Configure(filename string) (err error) {
 				os.RemoveAll(Config.File + ".yaml")
 				os.Exit(0)
 			}
+			Cache.Save()
 			sd.Status()
 
 		}
@@ -93,7 +97,10 @@ func Configure(filename string) (err error) {
 
 		case 1:
 			entry.account()
+			Cache.Token = ""
+			Cache.TokenExpires = 0
 			sd.Login()
+			Cache.Save()
 			sd.Status()
 
 		case 2:

--- a/data.go
+++ b/data.go
@@ -33,9 +33,22 @@ func (sd *SD) Update(filename string) (err error) {
 	if err != nil {
 		return err
 	}
-	err = sd.Login()
-	if err !=nil {
+
+	// load cache before login to check for cached token
+	err = Cache.Open()
+	if err != nil {
+		logger.Error("unable to open the cache", "error", err)
 		return err
+	}
+
+	err = sd.Login()
+	if err != nil {
+		return err
+	}
+
+	err = Cache.Save()
+	if err != nil {
+		logger.Warn("unable to save token to cache", "error", err)
 	}
 
 	err = sd.Status()

--- a/sd.go
+++ b/sd.go
@@ -11,13 +11,25 @@ import (
 
 var Token string
 
+const tokensafeMargin = 5 * time.Minute
+
 // Init : Init Schedules Direct
 func (sd *SD) Init() (err error) {
-
 	sd.BaseURL = "https://json.schedulesdirect.org/20141201/"
 
 	// Funtion to get token
 	sd.Login = func() (err error) {
+		if Cache.Token != "" && Cache.TokenExpires > 0 {
+			expiresAt := time.Unix(Cache.TokenExpires, 0)
+			safetyMargin := time.Now().Add(tokensafeMargin)
+			if expiresAt.After(safetyMargin) {
+				logger.Info("Using cached token", "expires", expiresAt)
+				sd.Token = Cache.Token
+				Token = Cache.Token
+				return nil
+			}
+			logger.Info("Cached token expired or expiring soon, requesting new token")
+		}
 
 		sd.Req.URL = sd.BaseURL + "token"
 		sd.Req.Type = "POST"
@@ -43,12 +55,15 @@ func (sd *SD) Init() (err error) {
 
 		sd.Token = sd.Resp.Login.Token
 		Token = sd.Token
+
+		Cache.Token = sd.Token
+		Cache.TokenExpires = sd.Resp.Login.TokenExpires
+
 		return
 	}
 
 	// Status function to check status of schedules direct API
 	sd.Status = func() (err error) {
-
 		fmt.Println()
 
 		sd.Req.URL = sd.BaseURL + "status"

--- a/struct_cache.go
+++ b/struct_cache.go
@@ -11,6 +11,9 @@ type cache struct {
 	Metadata map[string]EPGoCache   `json:"Metadata"`
 	Schedule map[string][]EPGoCache `json:"Schedule"`
 
+	Token        string `json:"Token,omitempty"`
+	TokenExpires int64  `json:"TokenExpires,omitempty"`
+
 	sync.RWMutex `json:"-"`
 }
 


### PR DESCRIPTION
Recently my Schedules Direct account was banned for some time because EpGo was requesting a new token even when the old token should have been used.

This PR updates the caching to include the token for re-use when possible, checking for expiry before requesting a new one.